### PR TITLE
Fix missing .on in exercise 11

### DIFF
--- a/src/exercises/11.js
+++ b/src/exercises/11.js
@@ -91,12 +91,12 @@ class Toggle extends React.Component {
   reset = () =>
     this.internalSetState(
       {...this.initialState, type: Toggle.stateChangeTypes.reset},
-      () => this.props.onReset(this.getState()),
+      () => this.props.onReset(this.getState().on),
     )
   toggle = ({type = Toggle.stateChangeTypes.toggle} = {}) =>
     this.internalSetState(
       ({on}) => ({type, on: !on}),
-      () => this.props.onToggle(this.getState()),
+      () => this.props.onToggle(this.getState().on),
     )
   getTogglerProps = ({onClick, ...props} = {}) => ({
     onClick: callAll(onClick, () => this.toggle()),


### PR DESCRIPTION
These go missing in exercise 11, but are present in exercise 10 and in the final solution to exercise 11. They only seem to cause issues in tests if you try to extra exercise of preserving the render prop API.