### PR TITLE
Switch a11y tweaks

### DIFF
--- a/src/__tests__/10.js
+++ b/src/__tests__/10.js
@@ -30,22 +30,22 @@ function validateToggleInstance(instance) {
 
 test('toggling either toggle toggles both', () => {
   const handleToggle = jest.fn()
-  const {getAllByLabelText, rootInstance} = renderToggle(
+  const {getAllByTestId, rootInstance} = renderToggle(
     <Usage onToggle={handleToggle} />,
   )
   const [toggleInstance1, toggleInstance2] = findToggleInstances(
     rootInstance,
   )
-  const buttons = getAllByLabelText('Toggle')
+  const buttons = getAllByTestId('toggle-input')
   const [toggleButton1, toggleButton2] = buttons
-  Simulate.click(toggleButton1)
+  Simulate.change(toggleButton1)
   expect(toggleButton1).toBeOn()
   expect(toggleButton2).toBeOn()
 
   validateToggleInstance(toggleInstance1)
   validateToggleInstance(toggleInstance2)
 
-  Simulate.click(toggleButton2)
+  Simulate.change(toggleButton2)
   expect(toggleButton1).toBeOff()
   expect(toggleButton2).toBeOff()
 })

--- a/src/switch.js
+++ b/src/switch.js
@@ -9,7 +9,7 @@ import React from 'react'
 // (if we've gotten to that part)
 class Switch extends React.Component {
   render() {
-    const {on, className = '', ...props} = this.props
+    const {on, className = '', 'aria-label': ariaLabel, onClick, ...props} = this.props
     const btnClassName = [
       className,
       'toggle-btn',
@@ -18,21 +18,19 @@ class Switch extends React.Component {
       .filter(Boolean)
       .join(' ')
     return (
-      <div>
+      <label aria-label={ariaLabel || "Toggle"}>
         <input
           className="toggle-input"
           type="checkbox"
           checked={on}
-          onChange={() => {
-            // changing is handled by clicking the button
-          }}
+          onChange={onClick}
+          data-testid="toggle-input"
         />
-        <button
+        <span
           className={btnClassName}
-          aria-label="Toggle"
           {...props}
         />
-      </div>
+      </label>
     )
   }
 }

--- a/src/switch.styles.css
+++ b/src/switch.styles.css
@@ -18,7 +18,7 @@ by Mauricio Allende (https://mallendeo.com/)
   transition: all 0.4s ease;
   border: 2px solid #e8eae9;
 }
-.toggle-btn:focus::after,
+.toggle-input:focus + .toggle-btn::after,
 .toggle-btn:active::after {
   box-sizing: initial;
   box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1), 0 4px 0 rgba(0, 0, 0, 0.08),
@@ -53,5 +53,14 @@ by Mauricio Allende (https://mallendeo.com/)
   padding-right: 1.6em;
 }
 .toggle-input {
-  display: none;
+  /* visually hidden but still accessible */
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  white-space: nowrap;
 }

--- a/test/extensions.js
+++ b/test/extensions.js
@@ -4,21 +4,18 @@ import 'jest-dom/extend-expect'
 
 const extensions = {
   toBeOn(toggleButton) {
-    const on = toggleButton.classList.contains('toggle-btn-on')
+    const on = toggleButton.checked
     if (on) {
       return {
         message: () =>
           [
             `${matcherHint('.not.toBeOn', 'received', '')} ${chalk.dim(
-              '// it does not have the toggle-btn-on class',
+              '// it is not checked',
             )}`,
-            `Expected the given element to not contain the class name:`,
-            `  ${printExpected('toggle-btn-on')}`,
-            `Received element:`,
-            `  ${printReceived(toggleButton)}`,
+            `Expected the given element to not to be checked.`,
             '',
             `Because of this, ${chalk.bold(
-              `the button is in an ${chalk.underline('on')} state`,
+              `the switch is in an ${chalk.underline('on')} state`,
             )}`,
             '',
           ].join('\n'),
@@ -29,16 +26,13 @@ const extensions = {
         message: () =>
           [
             `${matcherHint('.toBeOn', 'received', '')} ${chalk.dim(
-              '// it has the toggle-btn-on class',
+              '// it is checked',
             )}`,
             '',
-            `Expected the given element to contain the class name:`,
-            `  ${printExpected('toggle-btn-on')}`,
-            `Received element:`,
-            `  ${printReceived(toggleButton)}`,
+            `Expected the given element to be checked.`,
             '',
             `Because of this, ${chalk.bold(
-              `the button is in an ${chalk.underline('off')} state`,
+              `the switch is in an ${chalk.underline('off')} state`,
             )}`,
             '',
           ].join('\n'),
@@ -47,21 +41,18 @@ const extensions = {
     }
   },
   toBeOff(toggleButton) {
-    const off = toggleButton.classList.contains('toggle-btn-off')
+    const off = !toggleButton.checked
     if (off) {
       return {
         message: () =>
           [
             `${matcherHint('.not.toBeOff', 'received', '')} ${chalk.dim(
-              '// it does not have the toggle-btn-off class',
+              '// it is checked',
             )}`,
-            `Expected the given element to not contain the class name:`,
-            `  ${printExpected('toggle-btn-off')}`,
-            `Received element:`,
-            `  ${printReceived(toggleButton)}`,
+            `Expected the given element to not be checked.`,
             '',
             `Because of this, ${chalk.bold(
-              `the button is in an ${chalk.underline('off')} state`,
+              `the switch is in an ${chalk.underline('off')} state`,
             )}`,
             '',
           ].join('\n'),
@@ -72,16 +63,13 @@ const extensions = {
         message: () =>
           [
             `${matcherHint('.toBeOff', 'received', '')} ${chalk.dim(
-              '// it has the toggle-btn-off class',
+              '// it is unchecked',
             )}`,
             '',
-            `Expected the given element to contain the class name:`,
-            `  ${printExpected('toggle-btn-off')}`,
-            `Received element:`,
-            `  ${printReceived(toggleButton)}`,
+            `Expected the given element to be unchecked.`,
             '',
             `Because of this, ${chalk.bold(
-              `the button is in an ${chalk.underline('on')} state`,
+              `the switch is in an ${chalk.underline('on')} state`,
             )}`,
             '',
           ].join('\n'),

--- a/test/utils.js
+++ b/test/utils.js
@@ -52,9 +52,10 @@ function renderToggle(ui) {
   const utils = render(<Root ref={rootRef}>{ui}</Root>)
   const switchInstance = findSwitchInstances(rootInstance)[0]
   validateSwitchInstance(switchInstance)
-  const toggleButton = utils.getByLabelText('Toggle')
+  const toggleButton = utils.getByTestId('toggle-input')
+
   return {
-    toggle: () => Simulate.click(utils.getByLabelText('Toggle')),
+    toggle: () => Simulate.change(utils.getByTestId('toggle-input')),
     toggleButton,
     rootInstance,
     ...utils,


### PR DESCRIPTION
During the workshop I noticed that you were using a combo of `input` + `button` in the `Switch` component to toggle state. This PR is a small refactoring to make it accessible to screen readers. In the original version I found the following issues:

* The input was `display: none` so it is not focusable and screen readers couldn't read it. I made it visually hidden (see the css file).
* The button has a different semantic meaning therefore when changing value (by clicking the btn) the screen reader would not announce the new state. With a checkbox that happens by default.
* Since the checkbox in my version is the main player now we can assert against its `checked` state, that's why I had to tweak the test utils/extension.
* The `input` was just used for its native switch nature (checked/unchecked) to update the `Switch` state, but it was controlled by a button - better use a label for that.

✌️☮️