### PR TITLE
Fix switch button never changes its state (#28)

### DIFF
--- a/src/switch.js
+++ b/src/switch.js
@@ -8,7 +8,8 @@ import React from 'react'
 // your `render` method or the `getTogglerProps` method
 // (if we've gotten to that part)
 class Switch extends React.Component {
-  onChangeHandler = () => {
+  onChangeHandler = e => {
+    e.preventDefault()
     this.props.onClick()
   }
   render() {


### PR DESCRIPTION
As seen in the discussion on #28, the missing `e.preventDefault()` call is preventing the switch from being toggled.

Readding it should fix this issue.