### PR TITLE
Fix e query param in elaboration and feedback link

### DIFF
--- a/src/__tests__/12.js
+++ b/src/__tests__/12.js
@@ -81,7 +81,7 @@ test('handles static properties', () => {
 // 3. Change submitted from `false` to `true`
 // 4. And you're all done!
 /*
-http://ws.kcd.im/?ws=react%20patterns&e=11&em=
+http://ws.kcd.im/?ws=react%20patterns&e=12&em=
 */
 test.skip('I submitted my elaboration and feedback', () => {
   const submitted = false // change this when you've submitted!


### PR DESCRIPTION
Just saw that the feedback & elaboration link in the test for exercise 12 was pointing to the wrong autofill query param value. Thanks for the workshop :)