### PR TITLE
Encode the email before using it as a URL parameter

### DIFF
--- a/scripts/autofill-feedback-email.js
+++ b/scripts/autofill-feedback-email.js
@@ -40,7 +40,7 @@ if (isCI) {
     const options = {
       files: [path.join(__dirname, '..', 'src/**/*.js')],
       from: `&em=${EOL}`,
-      to: `&em=${email}${EOL}`,
+      to: `&em=${encodeURIComponent(email)}${EOL}`,
     }
 
     replace(options).then(


### PR DESCRIPTION
My email contains a **+** character which in URLs means a space. So in order to maintain it (*and other valid characters that have special meaning when in URLs*) we need to pass the `email` through `encodeURIComponent` before using it as a URL parameter.