### PR TITLE
Add toggle back spec for exercise 01

### DIFF
--- a/src/__tests__/01.js
+++ b/src/__tests__/01.js
@@ -15,6 +15,18 @@ test('renders a toggle component', () => {
   expect(handleToggle).toHaveBeenCalledWith(true)
 })
 
+test('can toggle back and forth', () => {
+  const handleToggle = jest.fn()
+  const {toggleButton, toggle} = renderToggle(
+    <Usage onToggle={handleToggle} />,
+  )
+  expect(toggleButton).toBeOff()
+  toggle()
+  expect(toggleButton).toBeOn()
+  toggle()
+  expect(toggleButton).toBeOff()
+})
+
 //////// Elaboration & Feedback /////////
 // When you've finished with the exercises:
 // 1. Copy the URL below into your browser and fill out the form


### PR DESCRIPTION
Hi, 

Doing the training at Frontend Masters, i run into an issue where my code passed the spec but it wasn't working as expected.

Basically, if in exercise one, you don't toggle the `on` value, but you just set it to `true`, the tests were passing. The solution could look like:

```
toggle = () => {
    this.setState(
      currentState => ({
        on: true,
      }),
      () => this.props.onToggle(this.state.on),
    )
  }
```

I've just added a new spec, to test this behaviour. Let me know what you think.